### PR TITLE
Fixed a double free crash.

### DIFF
--- a/src/pylzma/pylzma_compress.c
+++ b/src/pylzma/pylzma_compress.c
@@ -41,7 +41,7 @@ pylzma_compress(PyObject *self, PyObject *args, PyObject *kwargs)
     CLzmaEncProps props;
     CLzmaEncHandle encoder=NULL;
     CMemoryOutStream outStream;
-	outStream.data = NULL;
+    outStream.data = NULL;
     CMemoryInStream inStream;
     Byte header[LZMA_PROPS_SIZE];
     size_t headerSize = LZMA_PROPS_SIZE;


### PR DESCRIPTION
Fixed a crash that happend in some cases when compressobj destructor free's outstream's data. It checks if ouststream's data is not null before free'ing but data is never set to null after free'ing. Then it also tries to free outstream's data on exit and this leads to us trying to free the data twice. This leads to the following error when using pylzma: python: double free or corruption (out): 0x000000000166d5a0 ***

Thanks for creating this great library! :+1: 
