### PR TITLE
Add __version__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 *.so
 *.pyd
 RELEASE-VERSION
+src/pylzma/pylzma_version.h

--- a/src/pylzma/pylzma.c
+++ b/src/pylzma/pylzma.c
@@ -31,6 +31,7 @@
 #include "../7zip/C/Bra.h"
 
 #include "pylzma.h"
+#include "pylzma_version.h"
 #include "pylzma_compress.h"
 #include "pylzma_decompress.h"
 #include "pylzma_decompressobj.h"
@@ -279,6 +280,8 @@ initpylzma(void)
     PyModule_AddStringConstant(m, "SDK_DATE", MY_DATE);
     PyModule_AddStringConstant(m, "SDK_COPYRIGHT", MY_COPYRIGHT);
     PyModule_AddStringConstant(m, "SDK_VERSION_COPYRIGHT_DATE", MY_VERSION_COPYRIGHT_DATE);
+
+    PyModule_AddStringConstant(m, "__version__", PYLZMA_VERSION);
 
     AesGenTables();
     pylzma_init_compfile();

--- a/version.py
+++ b/version.py
@@ -75,6 +75,10 @@ def write_release_version(version):
     f.write("%s\n" % version)
     f.close()
 
+    f = open("src/pylzma/pylzma_version.h", "w")
+    f.write('#define PYLZMA_VERSION "%s"\n' % version)
+    f.close()
+
 
 def get_git_version(abbrev=4):
     # Read in the version that's currently in RELEASE-VERSION.


### PR DESCRIPTION
Added __version__ attr to package so that scripts that check local
packages to see if newer versions are available can work.

Almost all Python packages have a version attr, and the vast majority of
them name it "__version__"
