### PR TITLE
Python 3 Compatibility

### DIFF
--- a/tests/test_7zfiles.py
+++ b/tests/test_7zfiles.py
@@ -110,34 +110,33 @@ class Test7ZipFiles(unittest.TestCase):
                 cf = archive.getmember(filename)
                 self.assertEqual(len(cf.read()), cf.uncompressed)
 
-    if sys.version_info[:2] < (3, 0):
+    def test_encrypted_no_password(self):
+        # test loading of encrypted files without password (can read archived filenames)
+        with open(os.path.join(ROOT, 'data', 'encrypted.7z'), 'rb') as fp:
+            archive = Archive7z(fp)
+            filenames = archive.getnames()
+            self.assertEqual(sorted(archive.getnames()), sorted(['test1.txt', 'test/test2.txt']))
+            self.assertRaises(NoPasswordGivenError, archive.getmember('test1.txt').read)
+            self.assertRaises(NoPasswordGivenError, archive.getmember('test/test2.txt').read)
 
-        def test_encrypted_no_password(self):
-            # test loading of encrypted files without password (can read archived filenames)
-            with open(os.path.join(ROOT, 'data', 'encrypted.7z'), 'rb') as fp:
-                archive = Archive7z(fp)
-                filenames = archive.getnames()
-                self.assertEqual(sorted(archive.getnames()), sorted(['test1.txt', 'test/test2.txt']))
-                self.assertTrueRaises(NoPasswordGivenError, archive.getmember('test1.txt').read)
-                self.assertTrueRaises(NoPasswordGivenError, archive.getmember('test/test2.txt').read)
-
-        def test_encrypted_password(self):
-            # test loading of encrypted files with correct password
-            fp = open(os.path.join(ROOT, 'data', 'encrypted.7z'), 'rb')
+    def test_encrypted_password(self):
+        # test loading of encrypted files with correct password
+        with open(os.path.join(ROOT, 'data', 'encrypted.7z'), 'rb') as fp:
             archive = Archive7z(fp, password='secret')
             filenames = archive.getnames()
             for filename in filenames:
                 cf = archive.getmember(filename)
-                self.assertEqual(len(cf.read()), cf.uncompressed)
+                data = cf.read()
+                self.assertEqual(len(data), cf.uncompressed)
 
-        def test_encrypted_wong_password(self):
-            # test loading of encrypted files with wrong password
-            with open(os.path.join(ROOT, 'data', 'encrypted.7z'), 'rb') as fp:
-                archive = Archive7z(fp, password='password')
-                filenames = archive.getnames()
-                for filename in filenames:
-                    cf = archive.getmember(filename)
-                    self.assertTrueRaises(WrongPasswordError, cf.read)
+    def test_encrypted_wong_password(self):
+        # test loading of encrypted files with wrong password
+        with open(os.path.join(ROOT, 'data', 'encrypted.7z'), 'rb') as fp:
+            archive = Archive7z(fp, password='password')
+            filenames = archive.getnames()
+            for filename in filenames:
+                cf = archive.getmember(filename)
+                self.assertRaises(WrongPasswordError, cf.read)
 
     def test_deflate(self):
         # test loading of deflate compressed files
@@ -157,15 +156,15 @@ class Test7ZipFiles(unittest.TestCase):
 
     def test_regress_1(self):
         # prevent regression bug #1 reported by mail
-        fp = open(os.path.join(ROOT, 'data', 'regress_1.7z'), 'rb')
-        archive = Archive7z(fp)
-        filenames = list(archive.getnames())
-        self.assertEqual(len(filenames), 1)
-        cf = archive.getmember(filenames[0])
-        self.assertNotEqual(cf, None)
-        self.assertTrue(cf.checkcrc())
-        data = cf.read()
-        self.assertEqual(len(data), cf.size)
+        with open(os.path.join(ROOT, 'data', 'regress_1.7z'), 'rb') as fp:
+            archive = Archive7z(fp)
+            filenames = list(archive.getnames())
+            self.assertEqual(len(filenames), 1)
+            cf = archive.getmember(filenames[0])
+            self.assertNotEqual(cf, None)
+            self.assertTrue(cf.checkcrc())
+            data = cf.read()
+            self.assertEqual(len(data), cf.size)
 
     def test_bugzilla_16(self):
         # sample file for bugzilla #16

--- a/tests/test_7zfiles.py
+++ b/tests/test_7zfiles.py
@@ -53,27 +53,27 @@ ROOT = os.path.abspath(os.path.split(__file__)[0])
 class Test7ZipFiles(unittest.TestCase):
     
     def _test_archive(self, filename):
-        fp = open(os.path.join(ROOT, 'data', filename), 'rb')
-        archive = Archive7z(fp)
-        self.failUnlessEqual(sorted(archive.getnames()), ['test/test2.txt', 'test1.txt'])
-        self.failUnlessEqual(archive.getmember('test2.txt'), None)
-        cf = archive.getmember('test1.txt')
-        self.failUnless(cf.checkcrc())
-        self.failUnlessEqual(cf.lastwritetime // 10000000, 12786932628)
-        self.failUnlessEqual(cf.lastwritetime.as_datetime().replace(microsecond=0), \
-            datetime(2006, 3, 15, 21, 43, 48, 0, UTC))
-        self.failUnlessEqual(cf.read(), bytes('This file is located in the root.', 'ascii'))
-        cf.reset()
-        self.failUnlessEqual(cf.read(), bytes('This file is located in the root.', 'ascii'))
+        with open(os.path.join(ROOT, 'data', filename), 'rb') as fp:
+            archive = Archive7z(fp)
+            self.assertEqual(sorted(archive.getnames()), ['test/test2.txt', 'test1.txt'])
+            self.assertEqual(archive.getmember('test2.txt'), None)
+            cf = archive.getmember('test1.txt')
+            self.assertTrue(cf.checkcrc())
+            self.assertEqual(cf.lastwritetime // 10000000, 12786932628)
+            self.assertEqual(cf.lastwritetime.as_datetime().replace(microsecond=0), \
+                datetime(2006, 3, 15, 21, 43, 48, 0, UTC))
+            self.assertEqual(cf.read(), bytes('This file is located in the root.', 'ascii'))
+            cf.reset()
+            self.assertEqual(cf.read(), bytes('This file is located in the root.', 'ascii'))
 
-        cf = archive.getmember('test/test2.txt')
-        self.failUnless(cf.checkcrc())
-        self.failUnlessEqual(cf.lastwritetime // 10000000, 12786932616)
-        self.failUnlessEqual(cf.lastwritetime.as_datetime().replace(microsecond=0), \
-            datetime(2006, 3, 15, 21, 43, 36, 0, UTC))
-        self.failUnlessEqual(cf.read(), bytes('This file is located in a folder.', 'ascii'))
-        cf.reset()
-        self.failUnlessEqual(cf.read(), bytes('This file is located in a folder.', 'ascii'))
+            cf = archive.getmember('test/test2.txt')
+            self.assertTrue(cf.checkcrc())
+            self.assertEqual(cf.lastwritetime // 10000000, 12786932616)
+            self.assertEqual(cf.lastwritetime.as_datetime().replace(microsecond=0), \
+                datetime(2006, 3, 15, 21, 43, 36, 0, UTC))
+            self.assertEqual(cf.read(), bytes('This file is located in a folder.', 'ascii'))
+            cf.reset()
+            self.assertEqual(cf.read(), bytes('This file is located in a folder.', 'ascii'))
 
     def test_non_solid(self):
         # test loading of a non-solid archive
@@ -84,14 +84,14 @@ class Test7ZipFiles(unittest.TestCase):
         self._test_archive('solid.7z')
 
     def _test_umlaut_archive(self, filename):
-        fp = open(os.path.join(ROOT, 'data', filename), 'rb')
-        archive = Archive7z(fp)
-        self.failUnlessEqual(sorted(archive.getnames()), [unicode_string('t\xe4st.txt')])
-        self.failUnlessEqual(archive.getmember('test.txt'), None)
-        cf = archive.getmember(unicode_string('t\xe4st.txt'))
-        self.failUnlessEqual(cf.read(), bytes('This file contains a german umlaut in the filename.', 'ascii'))
-        cf.reset()
-        self.failUnlessEqual(cf.read(), bytes('This file contains a german umlaut in the filename.', 'ascii'))
+        with open(os.path.join(ROOT, 'data', filename), 'rb') as fp:
+            archive = Archive7z(fp)
+            self.assertEqual(sorted(archive.getnames()), [unicode_string('t\xe4st.txt')])
+            self.assertEqual(archive.getmember('test.txt'), None)
+            cf = archive.getmember(unicode_string('t\xe4st.txt'))
+            self.assertEqual(cf.read(), bytes('This file contains a german umlaut in the filename.', 'ascii'))
+            cf.reset()
+            self.assertEqual(cf.read(), bytes('This file contains a german umlaut in the filename.', 'ascii'))
         
     def test_non_solid_umlaut(self):
         # test loading of a non-solid archive containing files with umlauts
@@ -103,23 +103,23 @@ class Test7ZipFiles(unittest.TestCase):
 
     def test_bugzilla_4(self):
         # sample file for bugzilla #4
-        fp = open(os.path.join(ROOT, 'data', 'bugzilla_4.7z'), 'rb')
-        archive = Archive7z(fp)
-        filenames = archive.getnames()
-        for filename in filenames:
-            cf = archive.getmember(filename)
-            self.failUnlessEqual(len(cf.read()), cf.uncompressed)
+        with open(os.path.join(ROOT, 'data', 'bugzilla_4.7z'), 'rb') as fp:
+            archive = Archive7z(fp)
+            filenames = archive.getnames()
+            for filename in filenames:
+                cf = archive.getmember(filename)
+                self.assertEqual(len(cf.read()), cf.uncompressed)
 
     if sys.version_info[:2] < (3, 0):
 
         def test_encrypted_no_password(self):
             # test loading of encrypted files without password (can read archived filenames)
-            fp = open(os.path.join(ROOT, 'data', 'encrypted.7z'), 'rb')
-            archive = Archive7z(fp)
-            filenames = archive.getnames()
-            self.failUnlessEqual(sorted(archive.getnames()), sorted(['test1.txt', 'test/test2.txt']))
-            self.failUnlessRaises(NoPasswordGivenError, archive.getmember('test1.txt').read)
-            self.failUnlessRaises(NoPasswordGivenError, archive.getmember('test/test2.txt').read)
+            with open(os.path.join(ROOT, 'data', 'encrypted.7z'), 'rb') as fp:
+                archive = Archive7z(fp)
+                filenames = archive.getnames()
+                self.assertEqual(sorted(archive.getnames()), sorted(['test1.txt', 'test/test2.txt']))
+                self.assertTrueRaises(NoPasswordGivenError, archive.getmember('test1.txt').read)
+                self.assertTrueRaises(NoPasswordGivenError, archive.getmember('test/test2.txt').read)
 
         def test_encrypted_password(self):
             # test loading of encrypted files with correct password
@@ -128,16 +128,16 @@ class Test7ZipFiles(unittest.TestCase):
             filenames = archive.getnames()
             for filename in filenames:
                 cf = archive.getmember(filename)
-                self.failUnlessEqual(len(cf.read()), cf.uncompressed)
+                self.assertEqual(len(cf.read()), cf.uncompressed)
 
         def test_encrypted_wong_password(self):
             # test loading of encrypted files with wrong password
-            fp = open(os.path.join(ROOT, 'data', 'encrypted.7z'), 'rb')
-            archive = Archive7z(fp, password='password')
-            filenames = archive.getnames()
-            for filename in filenames:
-                cf = archive.getmember(filename)
-                self.failUnlessRaises(WrongPasswordError, cf.read)
+            with open(os.path.join(ROOT, 'data', 'encrypted.7z'), 'rb') as fp:
+                archive = Archive7z(fp, password='password')
+                filenames = archive.getnames()
+                for filename in filenames:
+                    cf = archive.getmember(filename)
+                    self.assertTrueRaises(WrongPasswordError, cf.read)
 
     def test_deflate(self):
         # test loading of deflate compressed files
@@ -160,61 +160,61 @@ class Test7ZipFiles(unittest.TestCase):
         fp = open(os.path.join(ROOT, 'data', 'regress_1.7z'), 'rb')
         archive = Archive7z(fp)
         filenames = list(archive.getnames())
-        self.failUnlessEqual(len(filenames), 1)
+        self.assertEqual(len(filenames), 1)
         cf = archive.getmember(filenames[0])
-        self.failIfEqual(cf, None)
-        self.failUnless(cf.checkcrc())
+        self.assertNotEqual(cf, None)
+        self.assertTrue(cf.checkcrc())
         data = cf.read()
-        self.failUnlessEqual(len(data), cf.size)
+        self.assertEqual(len(data), cf.size)
 
     def test_bugzilla_16(self):
         # sample file for bugzilla #16
-        fp = open(os.path.join(ROOT, 'data', 'bugzilla_16.7z'), 'rb')
-        archive = Archive7z(fp)
-        filenames = archive.getnames()
-        for filename in filenames:
-            cf = archive.getmember(filename)
-            self.failUnlessEqual(len(cf.read()), cf.uncompressed)
+        with open(os.path.join(ROOT, 'data', 'bugzilla_16.7z'), 'rb') as fp:
+            archive = Archive7z(fp)
+            filenames = archive.getnames()
+            for filename in filenames:
+                cf = archive.getmember(filename)
+                self.assertEqual(len(cf.read()), cf.uncompressed)
 
     def test_empty(self):
         # decompress empty archive
-        fp = open(os.path.join(ROOT, 'data', 'empty.7z'), 'rb')
-        archive = Archive7z(fp)
-        self.failUnlessEqual(archive.getnames(), [])
+        with open(os.path.join(ROOT, 'data', 'empty.7z'), 'rb') as fp:
+            archive = Archive7z(fp)
+            self.assertEqual(archive.getnames(), [])
 
     def test_github_14(self):
         # decompress content without filename
-        fp = open(os.path.join(ROOT, 'data', 'github_14.7z'), 'rb')
-        archive = Archive7z(fp)
-        self.failUnlessEqual(archive.getnames(), ['github_14'])
-        cf = archive.getmember('github_14')
-        self.failIfEqual(cf, None)
-        data = cf.read()
-        self.failUnlessEqual(len(data), cf.uncompressed)
-        self.failUnlessEqual(data, bytes('Hello GitHub issue #14.\n', 'ascii'))
+        with open(os.path.join(ROOT, 'data', 'github_14.7z'), 'rb') as fp:
+            archive = Archive7z(fp)
+            self.assertEqual(archive.getnames(), ['github_14'])
+            cf = archive.getmember('github_14')
+            self.assertNotEqual(cf, None)
+            data = cf.read()
+            self.assertEqual(len(data), cf.uncompressed)
+            self.assertEqual(data, bytes('Hello GitHub issue #14.\n', 'ascii'))
 
         # accessing by name returns an arbitrary compressed streams
         # if both don't have a name in the archive
-        fp = open(os.path.join(ROOT, 'data', 'github_14_multi.7z'), 'rb')
-        archive = Archive7z(fp)
-        self.failUnlessEqual(archive.getnames(), ['github_14_multi', 'github_14_multi'])
-        cf = archive.getmember('github_14_multi')
-        self.failIfEqual(cf, None)
-        data = cf.read()
-        self.failUnlessEqual(len(data), cf.uncompressed)
-        self.failUnless(data in (bytes('Hello GitHub issue #14 1/2.\n', 'ascii'), bytes('Hello GitHub issue #14 2/2.\n', 'ascii')))
+        with open(os.path.join(ROOT, 'data', 'github_14_multi.7z'), 'rb') as fp:
+            archive = Archive7z(fp)
+            self.assertEqual(archive.getnames(), ['github_14_multi', 'github_14_multi'])
+            cf = archive.getmember('github_14_multi')
+            self.assertNotEqual(cf, None)
+            data = cf.read()
+            self.assertEqual(len(data), cf.uncompressed)
+            self.assertTrue(data in (bytes('Hello GitHub issue #14 1/2.\n', 'ascii'), bytes('Hello GitHub issue #14 2/2.\n', 'ascii')))
 
-        # accessing by index returns both values
-        cf = archive.getmember(0)
-        self.failIfEqual(cf, None)
-        data = cf.read()
-        self.failUnlessEqual(len(data), cf.uncompressed)
-        self.failUnlessEqual(data, bytes('Hello GitHub issue #14 1/2.\n', 'ascii'))
-        cf = archive.getmember(1)
-        self.failIfEqual(cf, None)
-        data = cf.read()
-        self.failUnlessEqual(len(data), cf.uncompressed)
-        self.failUnlessEqual(data, bytes('Hello GitHub issue #14 2/2.\n', 'ascii'))
+            # accessing by index returns both values
+            cf = archive.getmember(0)
+            self.assertNotEqual(cf, None)
+            data = cf.read()
+            self.assertEqual(len(data), cf.uncompressed)
+            self.assertEqual(data, bytes('Hello GitHub issue #14 1/2.\n', 'ascii'))
+            cf = archive.getmember(1)
+            self.assertNotEqual(cf, None)
+            data = cf.read()
+            self.assertEqual(len(data), cf.uncompressed)
+            self.assertEqual(data, bytes('Hello GitHub issue #14 2/2.\n', 'ascii'))
 
 def suite():
     suite = unittest.TestSuite()

--- a/tests/test_pylzma.py
+++ b/tests/test_pylzma.py
@@ -58,7 +58,7 @@ class TestPyLZMA(unittest.TestCase):
         self.plain_without_eos = unhexlify('5d0000800000341949ee8def8c6b64909b1386e370bebeb1b656f5736d653c115edbe9')
 
     def test_version(self):
-        self.failIfEqual(pylzma.__version__, '')
+        self.assertNotEqual(pylzma.__version__, '')
 
     def test_compression_eos(self):
         # test compression with end of stream marker
@@ -205,7 +205,7 @@ class TestPyLZMA(unittest.TestCase):
         # decompress large block of repeating data, string version (bug reported by Christopher Perkins)
         data = bytes("asdf", 'ascii')*123456
         compressed = pylzma.compress(data)
-        self.failUnless(data == pylzma.decompress(compressed))
+        self.assertTrue(data == pylzma.decompress(compressed))
 
     def test_compress_large_stream(self):
         # decompress large block of repeating data, stream version (bug reported by Christopher Perkins)
@@ -218,7 +218,7 @@ class TestPyLZMA(unittest.TestCase):
             if not tmp: break
             outfile.write(decompress.decompress(tmp))
         outfile.write(decompress.flush())
-        self.failUnless(data == outfile.getvalue())
+        self.assertTrue(data == outfile.getvalue())
 
     def test_compress_large_stream_bigchunks(self):
         # decompress large block of repeating data, stream version with big chunks
@@ -231,19 +231,19 @@ class TestPyLZMA(unittest.TestCase):
             if not tmp: break
             outfile.write(decompress.decompress(tmp))
         outfile.write(decompress.flush())
-        self.failUnless(data == outfile.getvalue())
+        self.assertTrue(data == outfile.getvalue())
 
     def test_bugzilla_13(self):
         # prevent regression of bugzilla #13
         if sys.version_info[:2] < (3, 0):
             fp = pylzma.compressfile('/tmp/test')
-            self.failUnless(isinstance(fp, pylzma.compressfile))
+            self.assertTrue(isinstance(fp, pylzma.compressfile))
         else:
-            self.failUnlessRaises(TypeError, pylzma.compressfile, '/tmp/test')
+            self.assertRaises(TypeError, pylzma.compressfile, '/tmp/test')
 
     def test_github_10(self):
         # prevent regression of github #10
-        self.failUnlessRaises(ValueError, pylzma.compress, bytes("foo", 'ascii'), dictionary=100)
+        self.assertRaises(ValueError, pylzma.compress, bytes("foo", 'ascii'), dictionary=100)
 
 def suite():
     suite = unittest.TestSuite()

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -38,7 +38,7 @@ sys.path.insert(0, ROOT)
 def cleanup(path):
     try:
         shutil.rmtree(path)
-    except EnvironmentError, e:
+    except EnvironmentError as e:
         if e.errno != errno.ENOENT:
             raise
 


### PR DESCRIPTION
This PR addresses the following:

* Updates the assertions throughout the test suite to remove deprecated ones
* Updates the test suite to use context managers to ensure the test files are closed when the test is done.
* Fixed Python3 compatibility issues in py7zlib

Python 3.4.1 Test Results: 
```
tankbusta in ~/code/third_party/pylzma on fix_unittests λ python3 -m unittest discover
.......................................
----------------------------------------------------------------------
Ran 39 tests in 5.573s

OK
```

Python 2.7.8 Test Results:
```
tankbusta in ~/code/third_party/pylzma on fix_unittests λ python2 -m unittest discover
........................................
----------------------------------------------------------------------
Ran 40 tests in 5.315s

OK
```