### PR TITLE
Fixed issue with files getting negative _start's.

### DIFF
--- a/py7zlib.py
+++ b/py7zlib.py
@@ -360,9 +360,9 @@ class SubstreamsInfo(Base):
                 self.numunpackstreams.append(1)
         
         if id == PROPERTY_SIZE:
-            sum = 0
             self.unpacksizes = []
             for i in range(len(self.numunpackstreams)):
+                sum = 0
                 for j in range(1, self.numunpackstreams[i]):
                     size = self._read64Bit(file)
                     self.unpacksizes.append(size)
@@ -803,6 +803,7 @@ class Archive7z(Base):
                 src_pos += info['compressed']
             obidx += 1
             if idx >= subinfo.numunpackstreams[fidx]+folder_start:
+                pos = 0
                 folder_pos += packinfo.packsizes[fidx]
                 src_pos = folder_pos
                 folder_start = idx


### PR DESCRIPTION
I'm trying to open some large (~17 Gb; files here: https://www.kaggle.com/c/malware-classification/data) archives and I had issues with some unpacksizes becoming negative. I think the few small changes in this pull request fix that without breaking anything else?

I'm still having issues where not all files are completely read out (e.g. losing the ends) and it's extremely slow reading files out if they're near the end of a folder (perhaps it's impossible? related to https://github.com/fancycode/pylzma/issues/3 ?), but I don't think those are related issues.