### PR TITLE
ArchiveFile.read() should always returns bytes for consistency

### DIFF
--- a/py7zlib.py
+++ b/py7zlib.py
@@ -629,7 +629,7 @@ class ArchiveFile(Base):
     
     def read(self):
         if not self.size:
-            return ''
+            return b''
         elif not self._folder.coders:
             raise TypeError("file has no coder informations")
         


### PR DESCRIPTION
Signed-off-by: Hiroshi Miura <miurahr@linux.com>